### PR TITLE
nuget updates 

### DIFF
--- a/src/Rhino.Connectors.Text.IntegrationTests/Rhino.Connectors.Text.IntegrationTests.csproj
+++ b/src/Rhino.Connectors.Text.IntegrationTests/Rhino.Connectors.Text.IntegrationTests.csproj
@@ -9,13 +9,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.0.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.0.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 		<PackageReference Include="coverlet.collector" Version="3.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Rhino.Connectors.Simulator" Version="2022.12.21.3" />
+		<PackageReference Include="Rhino.Connectors.Simulator" Version="2022.12.29.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Rhino.Connectors.Text.UnitTests/Rhino.Connectors.Text.UnitTests.csproj
+++ b/src/Rhino.Connectors.Text.UnitTests/Rhino.Connectors.Text.UnitTests.csproj
@@ -9,13 +9,13 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.0.1" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.0.1" />
+		<PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+		<PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
 		<PackageReference Include="coverlet.collector" Version="3.2.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Rhino.Connectors.Simulator" Version="2022.12.21.3" />
+		<PackageReference Include="Rhino.Connectors.Simulator" Version="2022.12.29.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Rhino.Connectors.Text/Rhino.Connectors.Text.csproj
+++ b/src/Rhino.Connectors.Text/Rhino.Connectors.Text.csproj
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Rhino.Api" Version="2022.12.22.1" />
+	  <PackageReference Include="Rhino.Api" Version="2022.12.29.2" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updated Rhino.Api, MSTest Framework + Adapter and Rhino.Connectors.Simulator.

Rhino.Api update required for Rhino.Api update to resolve rhino-agent project compilation error.